### PR TITLE
Ajout du watcher sur notre docker compose

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -17,10 +17,10 @@ COPY . .
 COPY .env ./
 
 # Creates a "dist" folder with the production build
-RUN npm run build
+#RUN npm run build
 
 # Expose the port on which the app will run
 EXPOSE 3000
 
 # Start the server using the production build
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start:dev"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 name: micro-mars-services
-version: '3'
+version: "3"
 services:
   api-gateway:
     networks:
@@ -13,7 +13,14 @@ services:
       - ./api-gateway/.env
     depends_on:
       - mysql
-  
+    develop:
+      watch:
+        - action: sync
+          path: ./api-gateway
+          target: /usr/src/app
+          ignore:
+            - node_modules
+
   service-mailer:
     build:
       context: ./service-mailing
@@ -30,6 +37,13 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - mysql
+    develop:
+      watch:
+        - action: sync
+          path: ./service-command
+          target: /usr/src/app
+          ignore:
+            - node_modules
 
   service-auth:
     networks:
@@ -37,7 +51,14 @@ services:
     build:
       context: ./service-auth
       dockerfile: Dockerfile
-  
+    develop:
+      watch:
+        - action: sync
+          path: ./service-auth
+          target: /usr/src/app
+          ignore:
+            - node_modules
+
   service-front-gallery:
     build:
       context: ./front-gallery
@@ -51,14 +72,13 @@ services:
       - /app/node_modules
     command: npm run dev
 
-
   mysql:
     image: mysql:latest
     ports:
       - "3306:3306"
     env_file:
       - ./api-gateway/.env
-    command: --init-file /data/application/init.sql  
+    command: --init-file /data/application/init.sql
     volumes:
       - dbData:/var/lib/mysql
       - ./api-gateway/init.sql:/data/application/init.sql
@@ -82,7 +102,7 @@ services:
       - mysql
     networks:
       - kafka-kafdrop_default
-  
+
 volumes:
   dbData:
 

--- a/service-auth/Dockerfile
+++ b/service-auth/Dockerfile
@@ -14,10 +14,10 @@ RUN npm install
 COPY . .
 
 # Creates a "dist" folder with the production build
-RUN npm run build
+#RUN npm run build
 
 # Expose the port on which the app will run
 EXPOSE 3000
 
 # Start the server using the production build
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start:dev"]

--- a/service-command/Dockerfile
+++ b/service-command/Dockerfile
@@ -14,10 +14,10 @@ RUN npm install
 COPY . .
 
 # Creates a "dist" folder with the production build
-RUN npm run build
+#RUN npm run build
 
 # Expose the port on which the app will run
 EXPOSE 3000
 
 # Start the server using the production build
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start:dev"]


### PR DESCRIPTION
## Ajout du watcher sur notre docker compose

L'ajout du watcher nous permettra de mettre à jour l'image docker à l'enregistrement ou a l'évolution d'un fichier.

Appliquer sur : 
 - [x] Gateway
 - [x] auth service
 - [x] command service
Le watcher ne fonction que si on lance le docker compose avec la commande suivante : 

``` powershell
docker-compose watch
```